### PR TITLE
Add support for Sinovoip BananaPi M2 Ultra

### DIFF
--- a/brcmfmac43430-sdio.sinovoip,bpi-m2-ultra.txt
+++ b/brcmfmac43430-sdio.sinovoip,bpi-m2-ultra.txt
@@ -1,0 +1,54 @@
+#AP6212_NVRAM_V1.0_20140603
+# 2.4 GHz, 20 MHz BW mode
+
+# The following parameter values are just placeholders, need to be updated.
+manfid=0x2d0
+prodid=0x0726
+vendid=0x14e4
+devid=0x43e2
+boardtype=0x0726
+boardrev=0x1101
+boardnum=22
+macaddr=00:90:4c:c5:12:38
+sromrev=11
+boardflags=0x00404201
+xtalfreq=26000
+nocrc=1
+ag0=255
+aa2g=1
+ccode=ALL
+
+pa0itssit=0x20
+extpagain2g=0
+
+#PA parameters for 2.4GHz, measured at CHIP OUTPUT
+pa2ga0=-168,7161,-820
+AvVmid_c0=0x0,0xc8
+cckpwroffset0=5
+
+# PPR params
+maxp2ga0=90
+txpwrbckof=6
+cckbw202gpo=0x5555
+legofdmbw202gpo=0x77777777
+mcsbw202gpo=0xaaaaaaaa
+
+# OFDM IIR :
+ofdmdigfilttype=7
+# PAPD mode:
+papdmode=2
+
+il0macaddr=00:90:4c:c5:12:38
+wl0id=0x431b
+
+#OOB parameters
+hostwake=0x40
+hostrdy=0x41
+usbrdy=0x03
+usbrdydelay=100
+deadman_to=0xffffffff
+# muxenab: 0x1 for UART enable, 0x10 for Host awake
+muxenab=0x10
+# CLDO PWM voltage settings - 0x4 - 1.1 volt
+#cldo_pwm=0x4
+


### PR DESCRIPTION
BananaPi M2 Ultra has AP6212 wifi+bt module. Correct firmwares are already included in this repo, only missing thing is board configuration file, which this PR adds it.

BananaPi M2 Ultra PR will be opened in LE after this is merged.