### PR TITLE
Add nvram files for CuBox-i rev 1.3

### DIFF
--- a/brcmfmac4329-sdio.solidrun,cubox-i-dl.txt
+++ b/brcmfmac4329-sdio.solidrun,cubox-i-dl.txt
@@ -1,0 +1,70 @@
+# bcm4329 NVRAM
+# $Copyright (C) 2008 Broadcom Corporation$
+# $id$
+
+sromrev=3
+vendid=0x14e4
+devid=0x432f
+boardtype=0x53e
+
+boardrev=0x41
+
+#boardflags=0x1200
+boardflags=0x200
+
+# Specify the xtalfreq if it is otherthan 38.4MHz
+xtalfreq=37400
+
+aa2g=3
+aa5g=0
+
+ag0=255
+#tri2g=0x64
+
+# 11g paparams
+pa0b0=5542,5542,5542
+pa0b1=64244,64244,64244
+pa0b2=65202,65202,65202
+
+pa0itssit=62
+pa0maxpwr=74
+opo=0
+mcs2gpo0=0x6666
+mcs2gpo1=0x6666
+
+# 11g rssi params
+rssismf2g=0xa,0xa,0xa
+rssismc2g=0xb,0xb,0xb
+rssisav2g=0x3,0x3,0x3
+bxa2g=0
+
+# country code
+ccode=ALL
+cctl=0x0
+cckdigfilttype=0
+ofdmdigfilttype=1
+
+rxpo2g=0
+
+boardnum=1
+macaddr=00:90:4c:c5:00:34
+
+# xtal pu and pd time control variable
+# pu time is driver default (0x1501)
+#r13t=0x1501
+
+#######
+nocrc=1
+
+#for mfgc
+otpimagesize=182
+
+# sdio extra configs
+hwhdr=0x05ffff031030031003100000
+
+#This generates empty F1, F2 and F3 tuple chains, and may be used if the host SDIO stack does not require the standard tuples.
+#RAW1=80 02 fe ff
+
+#This includes the standard FUNCID and FUNCE tuples in the F1, F2, F3 and common CIS.
+RAW1=80 32 fe 21 02 0c 00 22 2a 01 01 00 00 c5 0 e6 00 00 00 00 00 40 00 00 ff ff 80 00 00 00 00 00 00 00 00 00 00 c8 00 00 00 00 00 00 00 00 00 00 00 00 00 ff 20 04 D0 2 29 43 21 02 0c 00 22 04 00 20 00 5A
+nvramver=4.218.214.0

--- a/brcmfmac4329-sdio.solidrun,cubox-i-q.txt
+++ b/brcmfmac4329-sdio.solidrun,cubox-i-q.txt
@@ -1,0 +1,70 @@
+# bcm4329 NVRAM
+# $Copyright (C) 2008 Broadcom Corporation$
+# $id$
+
+sromrev=3
+vendid=0x14e4
+devid=0x432f
+boardtype=0x53e
+
+boardrev=0x41
+
+#boardflags=0x1200
+boardflags=0x200
+
+# Specify the xtalfreq if it is otherthan 38.4MHz
+xtalfreq=37400
+
+aa2g=3
+aa5g=0
+
+ag0=255
+#tri2g=0x64
+
+# 11g paparams
+pa0b0=5542,5542,5542
+pa0b1=64244,64244,64244
+pa0b2=65202,65202,65202
+
+pa0itssit=62
+pa0maxpwr=74
+opo=0
+mcs2gpo0=0x6666
+mcs2gpo1=0x6666
+
+# 11g rssi params
+rssismf2g=0xa,0xa,0xa
+rssismc2g=0xb,0xb,0xb
+rssisav2g=0x3,0x3,0x3
+bxa2g=0
+
+# country code
+ccode=ALL
+cctl=0x0
+cckdigfilttype=0
+ofdmdigfilttype=1
+
+rxpo2g=0
+
+boardnum=1
+macaddr=00:90:4c:c5:00:34
+
+# xtal pu and pd time control variable
+# pu time is driver default (0x1501)
+#r13t=0x1501
+
+#######
+nocrc=1
+
+#for mfgc
+otpimagesize=182
+
+# sdio extra configs
+hwhdr=0x05ffff031030031003100000
+
+#This generates empty F1, F2 and F3 tuple chains, and may be used if the host SDIO stack does not require the standard tuples.
+#RAW1=80 02 fe ff
+
+#This includes the standard FUNCID and FUNCE tuples in the F1, F2, F3 and common CIS.
+RAW1=80 32 fe 21 02 0c 00 22 2a 01 01 00 00 c5 0 e6 00 00 00 00 00 40 00 00 ff ff 80 00 00 00 00 00 00 00 00 00 00 c8 00 00 00 00 00 00 00 00 00 00 00 00 00 ff 20 04 D0 2 29 43 21 02 0c 00 22 04 00 20 00 5A
+nvramver=4.218.214.0

--- a/brcmfmac4330-sdio.solidrun,cubox-i-dl.txt
+++ b/brcmfmac4330-sdio.solidrun,cubox-i-dl.txt
@@ -1,0 +1,118 @@
+manfid=0x2d0
+prodid=0x0532
+vendid=0x14e4
+devid=0x4360
+boardtype=0x0532
+boardrev=0x20
+boardflags=0x10080201
+
+nocrc=1
+xtalfreq=37400
+xtalmode=0x20,0x4,0
+boardnum=22
+macaddr=00:90:4c:c5:12:38
+ag0=252
+ag1=252
+aa2g=1
+aa5g=1
+ccode=EU
+regrev=5
+
+#for BT-coexistence
+btc_params80=0
+btc_params6=10
+btc_params8=10000
+
+sd_gpout=0
+# sd_oobonly=1
+muxenab=0x10
+
+# 2G PA param_B42R 110927
+pa0b0=0x12E4
+pa0b1=0xFE09
+pa0b2=0xFF9A
+#pa0itssit=62
+rssismf2g=0xa
+rssismc2g=0x3
+rssisav2g=0x7
+
+# rssi params for 5GHz B42R_110803
+#rssismf5g=0x4
+rssismf5g=0xa
+rssismc5g=0x7
+rssisav5g=0x1
+#PA parameters for lower band
+pa1lob0=0x144F
+pa1lob1=0xFD6B
+pa1lob2=0xFF3B
+#PA parameters for midband
+pa1b0=0x139C
+pa1b1=0xFD87
+pa1b2=0xFF4F
+#PA parameters for high band
+pa1hib0=0x12CA
+pa1hib1=0xFD9A
+pa1hib2=0xFF4E
+
+# 2G PA offset
+maxp2ga0=64
+sromrev=3
+cckpo=0
+ofdm2gpo=0x66666666
+mcs2gpo0=0xaaaa
+mcs2gpo1=0xaaaa
+
+# 5G PA offset
+maxp5ga0=66
+maxp5gla0=66
+maxp5gha0=66
+ofdm5gpo=0x22222222
+ofdm5glpo=0x11111111
+ofdm5ghpo=0x22222222
+mcs5gpo0=0x6666
+mcs5gpo1=0x6666
+mcs5glpo0=0x5555
+mcs5glpo1=0x5555
+mcs5ghpo0=0x6666
+mcs5ghpo1=0x6666
+
+cckPwrOffset=4
+cckdigfilttype=22
+ofdmdigfilttype=2
+extpagain5g=2
+#wl0id=0x431b
+
+# For 2GHz Tx EVM/SM
+rfreg033=0x19
+rfreg033_cck=0x1d
+pacalidx2g=65
+dacrate2g=160
+txalpfbyp2g=1
+bphyscale=17
+
+# 5GHz LOFT and IQ CAL
+txgaintbl5g=1
+txiqlopapu5g=1
+txiqlopag5g=0x10
+iqlocalidx5g=24
+
+# 5GHz Noise CAL parameter
+noise_cal_po_5g=5
+noise_cal_enable_5g=0
+
+# 2GHz RxPER at low rates
+noise_cal_ref_2g=56
+noise_cal_po_bias_2g=-4
+noise_cal_enable_2g=1
+
+# Max input level on a-band
+triso5g=9
+
+# Tx power control, especially temp.
+tssitime=1
+
+#fc+1.7GHz Spur Elimination
+loidacmode5g=1
+
+swctrlmap_2g=0x84048404, 0x82028202, 0x84048404, 0x010202, 0x1ff
+swctrlmap_5g=0xC040C040, 0xB030A020, 0xA020C040, 0x010A02, 0x2F8

--- a/brcmfmac4330-sdio.solidrun,cubox-i-q.txt
+++ b/brcmfmac4330-sdio.solidrun,cubox-i-q.txt
@@ -1,0 +1,118 @@
+manfid=0x2d0
+prodid=0x0532
+vendid=0x14e4
+devid=0x4360
+boardtype=0x0532
+boardrev=0x20
+boardflags=0x10080201
+
+nocrc=1
+xtalfreq=37400
+xtalmode=0x20,0x4,0
+boardnum=22
+macaddr=00:90:4c:c5:12:38
+ag0=252
+ag1=252
+aa2g=1
+aa5g=1
+ccode=EU
+regrev=5
+
+#for BT-coexistence
+btc_params80=0
+btc_params6=10
+btc_params8=10000
+
+sd_gpout=0
+# sd_oobonly=1
+muxenab=0x10
+
+# 2G PA param_B42R 110927
+pa0b0=0x12E4
+pa0b1=0xFE09
+pa0b2=0xFF9A
+#pa0itssit=62
+rssismf2g=0xa
+rssismc2g=0x3
+rssisav2g=0x7
+
+# rssi params for 5GHz B42R_110803
+#rssismf5g=0x4
+rssismf5g=0xa
+rssismc5g=0x7
+rssisav5g=0x1
+#PA parameters for lower band
+pa1lob0=0x144F
+pa1lob1=0xFD6B
+pa1lob2=0xFF3B
+#PA parameters for midband
+pa1b0=0x139C
+pa1b1=0xFD87
+pa1b2=0xFF4F
+#PA parameters for high band
+pa1hib0=0x12CA
+pa1hib1=0xFD9A
+pa1hib2=0xFF4E
+
+# 2G PA offset
+maxp2ga0=64
+sromrev=3
+cckpo=0
+ofdm2gpo=0x66666666
+mcs2gpo0=0xaaaa
+mcs2gpo1=0xaaaa
+
+# 5G PA offset
+maxp5ga0=66
+maxp5gla0=66
+maxp5gha0=66
+ofdm5gpo=0x22222222
+ofdm5glpo=0x11111111
+ofdm5ghpo=0x22222222
+mcs5gpo0=0x6666
+mcs5gpo1=0x6666
+mcs5glpo0=0x5555
+mcs5glpo1=0x5555
+mcs5ghpo0=0x6666
+mcs5ghpo1=0x6666
+
+cckPwrOffset=4
+cckdigfilttype=22
+ofdmdigfilttype=2
+extpagain5g=2
+#wl0id=0x431b
+
+# For 2GHz Tx EVM/SM
+rfreg033=0x19
+rfreg033_cck=0x1d
+pacalidx2g=65
+dacrate2g=160
+txalpfbyp2g=1
+bphyscale=17
+
+# 5GHz LOFT and IQ CAL
+txgaintbl5g=1
+txiqlopapu5g=1
+txiqlopag5g=0x10
+iqlocalidx5g=24
+
+# 5GHz Noise CAL parameter
+noise_cal_po_5g=5
+noise_cal_enable_5g=0
+
+# 2GHz RxPER at low rates
+noise_cal_ref_2g=56
+noise_cal_po_bias_2g=-4
+noise_cal_enable_2g=1
+
+# Max input level on a-band
+triso5g=9
+
+# Tx power control, especially temp.
+tssitime=1
+
+#fc+1.7GHz Spur Elimination
+loidacmode5g=1
+
+swctrlmap_2g=0x84048404, 0x82028202, 0x84048404, 0x010202, 0x1ff
+swctrlmap_5g=0xC040C040, 0xB030A020, 0xA020C040, 0x010A02, 0x2F8


### PR DESCRIPTION
Files from https://github.com/SolidRun/meta-solidrun-arm-imx6/tree/fido/recipes-bsp/broadcom-nvram-config/files/solidrun-imx6