### PR TITLE
add support for Rock Pi4+

### DIFF
--- a/brcmfmac43456-sdio.radxa,rockpi4b-plus.txt
+++ b/brcmfmac43456-sdio.radxa,rockpi4b-plus.txt
@@ -1,0 +1,1 @@
+brcmfmac43456-sdio.radxa,rockpi4b.txt


### PR DESCRIPTION
Add nvram file for  Rock Pi4+ (RK3399), which has the same wifi chipset as the others have, but yet another compatible string.