### PR TITLE
Vero4k

### DIFF
--- a/brcmfmac43455-sdio.osmc,vero4k-plus.bin
+++ b/brcmfmac43455-sdio.osmc,vero4k-plus.bin
@@ -1,0 +1,1 @@
+brcmfmac43455-sdio.bin

--- a/brcmfmac43455-sdio.osmc,vero4k-plus.txt
+++ b/brcmfmac43455-sdio.osmc,vero4k-plus.txt
@@ -1,0 +1,1 @@
+brcmfmac43455-sdio.txt

--- a/brcmfmac43456-sdio.radxa,zero2.bin
+++ b/brcmfmac43456-sdio.radxa,zero2.bin
@@ -1,0 +1,1 @@
+brcmfmac43456-sdio.bin

--- a/brcmfmac43456-sdio.radxa,zero2.txt
+++ b/brcmfmac43456-sdio.radxa,zero2.txt
@@ -1,0 +1,1 @@
+brcmfmac43456-sdio.txt


### PR DESCRIPTION
This adds .bin/.txt symlinks for the Vero 4K+ and Radxa Zero2 boards.